### PR TITLE
Add ToCidrString()

### DIFF
--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -314,5 +314,90 @@ public class IPAddressRangeTest
             parsed.Is(expected, "Output of ToString() should be usable by Parse() and result in the same output");
         });
     }
-    
+
+    [TestMethod]
+    [TestCase("fe80::/10", 10)]
+    [TestCase("192.168.0.0/24", 24)]
+    [TestCase("192.168.0.0", 32)]
+    [TestCase("192.168.0.0-192.168.0.0", 32)]
+    [TestCase("fe80::", 128)]
+    [TestCase("192.168.0.0-192.168.0.255", 24)]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 16)]
+    public void PrefixLength_Success()
+    {
+        TestContext.Run((string input, int expected) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\", Expected: \"{1}\"", input, expected);
+            var output = IPAddressRange.Parse(input).PrefixLength();
+            Console.WriteLine("  Result: \"{0}\"", output);
+            output.Is(expected);
+        });
+    }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254", typeof(FormatException))]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe", typeof(FormatException))]
+    public void PrefixLength_Failures()
+    {
+        TestContext.Run((string input, Type expectedException) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\", Expected Exception: {1}", input, expectedException.Name);
+            try
+            {
+                IPAddressRange.Parse(input).PrefixLength();
+                Assert.Fail("Expected exception of type {0} to be thrown for input \"{1}\"", expectedException.Name, input);
+            }
+            catch (AssertFailedException)
+            {
+                throw; // allow Assert.Fail to pass through 
+            }
+            catch (Exception ex)
+            {
+                ex.GetType().Is(expectedException);
+            }
+        });
+    }
+
+    [TestMethod]
+    [TestCase("fe80::/10", "fe80::/10")]
+    [TestCase("192.168.0.0/24", "192.168.0.0/24")]
+    [TestCase("192.168.0.0", "192.168.0.0/32")]
+    [TestCase("192.168.0.0-192.168.0.0", "192.168.0.0/32")]
+    [TestCase("fe80::", "fe80::/128")]
+    [TestCase("192.168.0.0-192.168.0.255", "192.168.0.0/24")]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "fe80::/16")]
+    public void ToCidrString_Output()
+    {
+        TestContext.Run((string input, string expected) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\", Expected: \"{1}\"", input, expected);
+            var output = IPAddressRange.Parse(input).ToCidrString();
+            Console.WriteLine("  Result: \"{0}\"", output);
+            output.Is(expected);
+        });
+    }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254", typeof(FormatException))]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe", typeof(FormatException))]
+    public void ToCidrString_ThrowsOnNonCidr()
+    {
+        TestContext.Run((string input, Type expectedException) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\", Expected Exception: {1}", input, expectedException.Name);
+            try
+            {
+                IPAddressRange.Parse(input).ToCidrString();
+                Assert.Fail("Expected exception of type {0} to be thrown for input \"{1}\"", expectedException.Name, input);
+            }
+            catch (AssertFailedException)
+            {
+                throw; // allow Assert.Fail to pass through 
+            }
+            catch (Exception ex)
+            {
+                ex.GetType().Is(expectedException);
+            }
+        });
+    }
 }

--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -323,12 +323,12 @@ public class IPAddressRangeTest
     [TestCase("fe80::", 128)]
     [TestCase("192.168.0.0-192.168.0.255", 24)]
     [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 16)]
-    public void PrefixLength_Success()
+    public void GetPrefixLength_Success()
     {
         TestContext.Run((string input, int expected) =>
         {
             Console.WriteLine("TestCase: \"{0}\", Expected: \"{1}\"", input, expected);
-            var output = IPAddressRange.Parse(input).PrefixLength();
+            var output = IPAddressRange.Parse(input).GetPrefixLength();
             Console.WriteLine("  Result: \"{0}\"", output);
             output.Is(expected);
         });
@@ -337,14 +337,14 @@ public class IPAddressRangeTest
     [TestMethod]
     [TestCase("192.168.0.0-192.168.0.254", typeof(FormatException))]
     [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe", typeof(FormatException))]
-    public void PrefixLength_Failures()
+    public void GetPrefixLength_Failures()
     {
         TestContext.Run((string input, Type expectedException) =>
         {
             Console.WriteLine("TestCase: \"{0}\", Expected Exception: {1}", input, expectedException.Name);
             try
             {
-                IPAddressRange.Parse(input).PrefixLength();
+                IPAddressRange.Parse(input).GetPrefixLength();
                 Assert.Fail("Expected exception of type {0} to be thrown for input \"{1}\"", expectedException.Name, input);
             }
             catch (AssertFailedException)

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -218,7 +218,7 @@ namespace NetTools
             return Equals(Begin, End) ? Begin.ToString() : string.Format("{0}-{1}", Begin, End);
         }
 
-        public int PrefixLength()
+        public int GetPrefixLength()
         {
             byte[] byteBegin = Begin.GetAddressBytes();
             byte[] byteEnd = End.GetAddressBytes();
@@ -250,7 +250,7 @@ namespace NetTools
         /// </summary>
         public string ToCidrString()
         {
-            return string.Format("{0}/{1}", Begin, PrefixLength());
+            return string.Format("{0}/{1}", Begin, GetPrefixLength());
         }
     }
 }

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -217,5 +217,40 @@ namespace NetTools
         {
             return Equals(Begin, End) ? Begin.ToString() : string.Format("{0}-{1}", Begin, End);
         }
+
+        public int PrefixLength()
+        {
+            byte[] byteBegin = Begin.GetAddressBytes();
+            byte[] byteEnd = End.GetAddressBytes();
+
+            // Handle single IP
+            if (Begin.Equals(End))
+            {
+                return byteBegin.Length * 8;
+            }
+
+            int length = byteBegin.Length * 8;
+
+            for (int i = 0; i < length; i++)
+            {
+                byte[] mask = Bits.GetBitMask(byteBegin.Length, i);
+                if (new IPAddress(Bits.And(byteBegin, mask)).Equals(Begin))
+                {
+                    if (new IPAddress(Bits.Or(byteBegin, Bits.Not(mask))).Equals(End))
+                    {
+                        return i;
+                    }
+                }
+            }
+            throw new FormatException(string.Format("{0} is not a CIDR Subnet", ToString()));
+        }
+
+        /// <summary>
+        /// Returns a Cidr String if this matches exactly a Cidr subnet
+        /// </summary>
+        public string ToCidrString()
+        {
+            return string.Format("{0}/{1}", Begin, PrefixLength());
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ using NetTools;
 var rangeA = IPAddressRange.Parse("192.168.0.0/255.255.255.0");
 rangeA.Contains(IPAddress.Parse("192.168.0.34")); // is True.
 rangeA.Contains(IPAddress.Parse("192.168.10.1")); // is False.
+rangeA.ToCidrString(); // is 192.168.0.0/24
 
 // rangeB.Begin is "192.168.0.10", and rangeB.End is "192.168.10.20".
 var rangeB = IPAddressRange.Parse("192.168.0.10 - 192.168.10.20");
@@ -47,6 +48,9 @@ var rangeF = new IPAddressRange(ipBegin, ipEnd);
 var rangeG = new IPAddressRange(ipBegin, maskLength: 24);
 var rangeH = new IPAddressRange(ipBegin, IPAddressRange.SubnetMaskLength(ipSubnet));
 
+// Calculates Cidr subnets
+var rangeI = IPAddressRange.Parse("192.168.0.0-192.168.0.254");
+rangeI.ToCidrString();  // is 192.168.0.0/24
 ```
 
 License


### PR DESCRIPTION
This PR adds a `.ToCidrString()` and .`PrefixLength()` which returns a Cidr notation form of a subnet, if the subnet exactly matches a range.

Examples:
```
IPAddressRange.Parse("192.168.0.0-192.168.0.255").PrefixLength(); // 24
IPAddressRange.Parse("192.168.0.0-192.168.0.255").ToCidrString(); // 192.168.0.0/24
IPAddressRange.Parse("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff").PrefixLength(); // 16
IPAddressRange.Parse("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:ffff").ToCidrString(); // fe80::/16
```
If Begin and End do not align with any valid subnets, then FormatException is thrown.