### PR TITLE
Optimize IP comparison

### DIFF
--- a/IPAddressRange/Bits.cs
+++ b/IPAddressRange/Bits.cs
@@ -10,31 +10,53 @@ namespace NetTools
     {
         public static byte[] Not(byte[] bytes)
         {
-            return bytes.Select(b => (byte)~b).ToArray();
+            var result = (byte[])bytes.Clone();
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = (byte)~result[i];
+            }
+            return result;
+            //return bytes.Select(b => (byte)~b).ToArray();
         }
 
         public static byte[] And(byte[] A, byte[] B)
         {
-            return A.Zip(B, (a, b) => (byte)(a & b)).ToArray();
+            var result = (byte[])A.Clone();
+            for (var i = 0; i < A.Length; i++)
+            {
+                result[i] &= B[i];
+            }
+            return result;
+            //return A.Zip(B, (a, b) => (byte)(a & b)).ToArray();
         }
 
         public static byte[] Or(byte[] A, byte[] B)
         {
-            return A.Zip(B, (a, b) => (byte)(a | b)).ToArray();
+            var result = (byte[])A.Clone();
+            for (var i = 0; i < A.Length; i++)
+            {
+                result[i] |= B[i];
+            }
+            return result;
+            //return A.Zip(B, (a, b) => (byte)(a | b)).ToArray();
         }
 
-        public static bool GE(byte[] A, byte[] B)
+        public static bool GE(byte[] A, byte[] B, int offset = 0)
         {
-            return A.Zip(B, (a, b) => a == b ? 0 : a < b ? 1 : -1)
-                .SkipWhile(c => c == 0)
-                .FirstOrDefault() >= 0;
+            for (var i = 0; i < A.Length; i++)
+            {
+                if (A[i] != B[i]) return A[i] <= B[i];
+            }
+            return true;
         }
 
-        public static bool LE(byte[] A, byte[] B)
+        public static bool LE(byte[] A, byte[] B, int offset = 0)
         {
-            return A.Zip(B, (a, b) => a == b ? 0 : a < b ? 1 : -1)
-                .SkipWhile(c => c == 0)
-                .FirstOrDefault() <= 0;
+            for (var i = 0; i < A.Length; i++)
+            {
+                if (A[i] != B[i]) return A[i] >= B[i];
+            }
+            return true;
         }
 
         public static bool IsEqual(byte[] A, byte[] B)

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -176,8 +176,15 @@ namespace NetTools
                 throw new ArgumentNullException(nameof(ipaddress));
 
             if (ipaddress.AddressFamily != this.Begin.AddressFamily) return false;
+            
+            var offset = 0;
+            if (Begin.IsIPv4MappedToIPv6 && ipaddress.IsIPv4MappedToIPv6)
+            {
+                offset = 12; //ipv4 has prefix of 10 zero bytes and two 255 bytes. 
+            }
+
             var adrBytes = ipaddress.GetAddressBytes();
-            return Bits.GE(this.Begin.GetAddressBytes(), adrBytes) && Bits.LE(this.End.GetAddressBytes(), adrBytes);
+            return Bits.GE(this.Begin.GetAddressBytes(), adrBytes, offset) && Bits.LE(this.End.GetAddressBytes(), adrBytes, offset);
         }
 
         public bool Contains(IPAddressRange range)
@@ -186,10 +193,16 @@ namespace NetTools
                 throw new ArgumentNullException(nameof(range));
 
             if (this.Begin.AddressFamily != range.Begin.AddressFamily) return false;
+            
+            var offset = 0;
+            if (Begin.IsIPv4MappedToIPv6 && range.Begin.IsIPv4MappedToIPv6)
+            {
+                offset = 12; //ipv4 has prefix of 10 zero bytes and two 255 bytes. 
+            }
 
             return
-                Bits.GE(this.Begin.GetAddressBytes(), range.Begin.GetAddressBytes()) &&
-                Bits.LE(this.End.GetAddressBytes(), range.End.GetAddressBytes());
+                Bits.GE(this.Begin.GetAddressBytes(), range.Begin.GetAddressBytes(), offset) &&
+                Bits.LE(this.End.GetAddressBytes(), range.End.GetAddressBytes(), offset);
 
             throw new NotImplementedException();
         }


### PR DESCRIPTION
#38 has some ideas to speed up library. 
Implemented ideas: 
- LINQ extensions => for loop
- using offset for  IPv4 mapped to IPv6

Gained performance 
- Bit.GE : 82.1% time less - 3M calls -  24534 ms -> 4400 ms
- Bit.LE :  81.9% time less - 4 999 911 calls - 33004 ms -> 7063 ms

**Tests** 
IPv4 range parse
- 1M calls
- gained 5.42%

IPv6 range parse:
- 999 908 calls
- gained 13.85%

IPv6 Contains - called both LE and GE
- 1M calls
- gained 9.10%

IPv4 Contains - called both LE and GE
- 1M calls
- gained 2.91%

IPv4 mapped to IPv6 Contains - called both LE and GE
- 1M calls
- gained 10.22%

Not implemented: 
3. I'm not fully sure it's a good idea.
4.  Get hash code takes for IPv4 as the most significant byte the last octet. `1.0.0.255` > `1.0.1.0`