### PR TITLE
GetHashCode and Equals methods are now overridden in IPAddressRange

### DIFF
--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -423,4 +423,60 @@ public class IPAddressRangeTest
             }
         });
     }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254")]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void GetHashCode_SameRange_HashCodesAreSame()
+    {
+        TestContext.Run((string input) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\"", input);
+            var range1 = IPAddressRange.Parse(input);
+            var range2 = IPAddressRange.Parse(input);
+            range1.GetHashCode().Is(range2.GetHashCode());
+        });
+    }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254", "192.168.0.1-192.168.0.254")]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe", "fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffd")]
+    public void GetHashCode_DifferentRanges_HashCodesAreDifferent()
+    {
+        TestContext.Run((string input1, string input2) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\" and \"{1}\"", input1, input2);
+            var range1 = IPAddressRange.Parse(input1);
+            var range2 = IPAddressRange.Parse(input2);
+            range1.GetHashCode().IsNot(range2.GetHashCode());
+        });
+    }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254")]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void Equals_SameRange_ReturnsTrue()
+    {
+        TestContext.Run((string input) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\"", input);
+            var range1 = IPAddressRange.Parse(input);
+            var range2 = IPAddressRange.Parse(input);
+            range1.Equals(range2).IsTrue();
+        });
+    }
+
+    [TestMethod]
+    [TestCase("192.168.0.0-192.168.0.254", "192.168.0.1-192.168.0.254")]
+    [TestCase("fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffe", "fe80::-fe80:ffff:ffff:ffff:ffff:ffff:ffff:fffd")]
+    public void Equals_SameRange_ReturnsFalse()
+    {
+        TestContext.Run((string input1, string input2) =>
+        {
+            Console.WriteLine("TestCase: \"{0}\" and \"{1}\"", input1, input2);
+            var range1 = IPAddressRange.Parse(input1);
+            var range2 = IPAddressRange.Parse(input2);
+            range1.Equals(range2).IsFalse();
+        });
+    }
 }

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -345,6 +345,25 @@ namespace NetTools
             return Equals(Begin, End) ? Begin.ToString() : string.Format("{0}-{1}", Begin, End);
         }
 
+        private bool Equals(IPAddressRange other)
+        {
+            return Begin.Equals(other.Begin) && End.Equals(other.End);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+
+            return Equals((IPAddressRange)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return new {Begin, End}.GetHashCode();
+        }
+
         public int GetPrefixLength()
         {
             byte[] byteBegin = Begin.GetAddressBytes();


### PR DESCRIPTION
It would be useful to override GetHashCode method for the IPAddressRange, so that e.g. it can be used as a key in dictionary.