### PR TITLE
Fix missing Operator creation for mask length constructor, add tests

### DIFF
--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -29,6 +29,7 @@ public class IPAddressRangeTest
         range.Begin.ToString().Is("192.168.0.88");
         range.End.AddressFamily.Is(AddressFamily.InterNetwork);
         range.End.ToString().Is("192.168.0.88");
+        range.Contains(range.Begin).Is(true);
     }
 
     [TestMethod]
@@ -39,6 +40,7 @@ public class IPAddressRangeTest
         range.Begin.ToString().Is("192.168.0.0");
         range.End.AddressFamily.Is(AddressFamily.InterNetwork);
         range.End.ToString().Is("192.168.0.255");
+        range.Contains(range.Begin).Is(true);
     }
 
     [TestMethod]
@@ -51,6 +53,7 @@ public class IPAddressRangeTest
         range.Begin.ToString().Is("ff80::1");
         range.End.AddressFamily.Is(AddressFamily.InterNetworkV6);
         range.End.ToString().Is("ff80::34");
+        range.Contains(range.Begin).Is(true);
     }
 
     [TestMethod]
@@ -63,6 +66,7 @@ public class IPAddressRangeTest
         range.Begin.ToString().Is("ff80::56");
         range.End.AddressFamily.Is(AddressFamily.InterNetworkV6);
         range.End.ToString().Is("ff80::789");
+        range.Contains(range.Begin).Is(true);
     }
 
     [TestMethod]

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -143,6 +143,8 @@ namespace NetTools
 
             Begin = new IPAddress(baseAdrBytes);
             End = new IPAddress(Bits.Or(baseAdrBytes, Bits.Not(maskBytes)));
+
+            Operator = RangeOperatorFactory.Create(this);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use IPAddressRange.Parse static method instead.")]


### PR DESCRIPTION
This PR adds in the missing Operator creation when using the mask length constructor.

I've also added a line to each of the constructor tests to verify it.

Fixes #64 