### PR TITLE
Begin and End property setter should re-create Operator instance.

### DIFF
--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -44,6 +44,30 @@ public class IPAddressRangeTest
     }
 
     [TestMethod]
+    public void CtorTest_IPv4_BeginEndAddresses()
+    {
+        var range = new IPAddressRange(
+            begin: IPAddress.Parse("192.168.0.0"),
+            end: IPAddress.Parse("192.168.0.255"));
+
+        range.Contains(IPAddress.Parse("192.168.0.10")).Is(true);
+        range.Contains(IPAddress.Parse("192.169.0.10")).Is(false);
+    }
+
+    [TestMethod]
+    public void CtorTest_IPv4_BeginEndAddresses_ObjectInitializer()
+    {
+        var range = new IPAddressRange
+        {
+            Begin = IPAddress.Parse("192.168.0.0"),
+            End = IPAddress.Parse("192.168.0.255")
+        };
+
+        range.Contains(IPAddress.Parse("192.168.0.10")).Is(true);
+        range.Contains(IPAddress.Parse("192.169.0.10")).Is(false);
+    }
+
+    [TestMethod]
     public void CtorTest_IPv6_BeginEndAddresses()
     {
         var range = new IPAddressRange(

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -75,9 +75,28 @@ namespace NetTools
         // Pattern 4. Bit mask range: "192.168.0.0/255.255.255.0"
         private static Regex m4_regex = new Regex(@"^(?<adr>([\d.]+)|([\da-f:]+(:[\d.]+)?(%\w+)?))[ \t]*/[ \t]*(?<bitmask>[\da-f\.:]+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public IPAddress Begin { get; set; }
+        private IPAddress BeginValue;
+        public IPAddress Begin
+        {
+            get => BeginValue;
+            set
+            {
+                if (BeginValue == value) return;
+                BeginValue = value;
+                if (Operator != null) Operator = RangeOperatorFactory.Create(this);
+            }
+        }
 
-        public IPAddress End { get; set; }
+        private IPAddress EndValue;
+        public IPAddress End {
+            get => EndValue;
+            set
+            {
+                if (EndValue == value) return;
+                EndValue = value;
+                if (Operator != null) Operator = RangeOperatorFactory.Create(this);
+            }
+        }
 
         private IRangeOperator Operator { get; set; }
 


### PR DESCRIPTION
Hello.
Begin and End property setter should re-create Operator instance. #68 
Would you see this test code?

```C#
    [TestMethod]
    public void CtorTest_IPv4_BeginEndAddresses()
    {
        var range = new IPAddressRange(
            begin: IPAddress.Parse("192.168.0.0"),
            end: IPAddress.Parse("192.168.0.255"));
        range.Contains(IPAddress.Parse("192.168.0.10")).Is(true);
        range.Contains(IPAddress.Parse("192.169.0.10")).Is(false);
    }
    // error IPAddressRange 4.1.2
    [TestMethod]
    public void CtorTest_IPv4_BeginEndAddresses_ObjectInitializer()
    {
        var range = new IPAddressRange
        {
            Begin = IPAddress.Parse("192.168.0.0"),
            End = IPAddress.Parse("192.168.0.255")
        };
        range.Contains(IPAddress.Parse("192.168.0.10")).Is(true);
        range.Contains(IPAddress.Parse("192.169.0.10")).Is(false);
    }
```