### PR TITLE
Added property to retrieve total address count contained by the range

### DIFF
--- a/IPAddressRange.Test/IPAddressRangeTest.cs
+++ b/IPAddressRange.Test/IPAddressRangeTest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-
+using System.Numerics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using NetTools;
@@ -121,6 +121,47 @@ namespace IPRange.Test
             range.Begin.ToString().Is("192.168.60.26");
             range.End.AddressFamily.Is(AddressFamily.InterNetwork);
             range.End.ToString().Is("192.168.60.37");
+        }
+
+        [DataTestMethod]
+        [DataRow("192.168.1.1", 1u)]
+        [DataRow("192.168.1.1/32", 1u)]
+        [DataRow("192.168.1.0/24", 256u)]
+        [DataRow("173.0.0.0/8", 16777216u)]
+        [DataRow("128.0.0.0/1", 2147483648u)]
+        public void AddressCountTest_IPv4(string rangeStr, uint expectedAddressCount)
+        {
+            var range = IPAddressRange.Parse(rangeStr);
+
+            range.AddressCount.Is(expectedAddressCount);
+        }
+
+        [TestMethod]
+        public void AddressCountTest_IPv4_AllAddresses()
+        {
+            var fullIPv4Range = IPAddressRange.Parse("0.0.0.0/0");
+
+            fullIPv4Range.AddressCount.Is(BigInteger.Pow(2, 32));
+        }
+
+        [DataTestMethod]
+        [DataRow("2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1")]
+        [DataRow("2001:0db8:85a3:0000:0000:8a2e:0370:7334/128", "1")]
+        [DataRow("2001:0db8:85a3:0000:0000:8a2e::/96", "4294967296")]
+        [DataRow("2001:0db8:85a3::/64", "18446744073709551616")]
+        public void AddressCountTest_IPv6(string rangeStr, string expectedAddressCountStr)
+        {
+            var range = IPAddressRange.Parse(rangeStr);
+
+            range.AddressCount.Is(BigInteger.Parse(expectedAddressCountStr));
+        }
+
+        [TestMethod]
+        public void AddressCountTest_IPv6_AllAddresses()
+        {
+            var fullIPv6Range = IPAddressRange.Parse("::/0");
+
+            fullIPv6Range.AddressCount.Is(BigInteger.Pow(2, 128));
         }
 
         [TestMethod]

--- a/IPAddressRange/IPAddressRange.cs
+++ b/IPAddressRange/IPAddressRange.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using System.Text.RegularExpressions;
 using NetTools.Internals;
 
@@ -96,6 +97,13 @@ namespace NetTools
                 return _Operator;
             }
         }
+
+        /// <summary>
+        /// Number of addresses contained in this range.
+        /// Works both for IPv4 and IPv6 addresses.
+        /// </summary>
+        public BigInteger AddressCount
+            => Operator.AddressCount;
 
         // variable for store prefix length
         private int _prefixLength = EMPTYPREFIXLENGTH;

--- a/IPAddressRange/IPAddressRange.csproj
+++ b/IPAddressRange/IPAddressRange.csproj
@@ -15,7 +15,7 @@
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <NuspecFile>IPAddressRange.nuspec</NuspecFile>
     <Copyright>Copyright © 2012-2024 J.Sakamoto, Mozilla Public License 2.0</Copyright>
-    <Version>6.1.0</Version>
+    <Version>6.2.0</Version>
     <Authors>J.Sakamoto</Authors>
     <Company />
     <Product>IPAddressRange</Product>

--- a/IPAddressRange/Internals/IPv4RangeOperator.cs
+++ b/IPAddressRange/Internals/IPv4RangeOperator.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Numerics;
 
 namespace NetTools.Internals
 {
@@ -10,6 +11,8 @@ namespace NetTools.Internals
         private UInt32 Begin { get; }
 
         private UInt32 End { get; }
+
+        public BigInteger AddressCount => (BigInteger)this.End - this.Begin + 1;
 
         public IPv4RangeOperator(IPAddressRange range)
         {
@@ -39,7 +42,7 @@ namespace NetTools.Internals
             }
         }
 
-        int ICollection<IPAddress>.Count => (int)((this.End - this.Begin) + 1);
+        int ICollection<IPAddress>.Count => (int)AddressCount;
 
         bool ICollection<IPAddress>.IsReadOnly => true;
 
@@ -54,7 +57,7 @@ namespace NetTools.Internals
 
         void ICollection<IPAddress>.CopyTo(IPAddress[] array, int arrayIndex)
         {
-            if ((array.Length - arrayIndex) < (this as ICollection<IPAddress>).Count) throw new ArgumentException();
+            if ((array.Length - arrayIndex) < AddressCount) throw new ArgumentException();
 
             foreach (var ipAddress in this)
             {

--- a/IPAddressRange/Internals/IPv6RangeOperator.cs
+++ b/IPAddressRange/Internals/IPv6RangeOperator.cs
@@ -12,6 +12,8 @@ namespace NetTools.Internals
 
         private BigInteger End { get; }
 
+        public BigInteger AddressCount => this.End - this.Begin + 1;
+
         public IPv6RangeOperator(IPAddressRange range)
         {
             this.Begin = range.Begin.ToBigInteger();
@@ -40,7 +42,7 @@ namespace NetTools.Internals
             }
         }
 
-        int ICollection<IPAddress>.Count => (int)((this.End - this.Begin) + 1);
+        int ICollection<IPAddress>.Count => (int)AddressCount;
 
         bool ICollection<IPAddress>.IsReadOnly => true;
 
@@ -55,7 +57,7 @@ namespace NetTools.Internals
 
         void ICollection<IPAddress>.CopyTo(IPAddress[] array, int arrayIndex)
         {
-            if ((array.Length - arrayIndex) < (this as ICollection<IPAddress>).Count) throw new ArgumentException();
+            if ((array.Length - arrayIndex) < AddressCount) throw new ArgumentException();
 
             foreach (var ipAddress in this)
             {

--- a/IPAddressRange/Internals/IRangeOperator.cs
+++ b/IPAddressRange/Internals/IRangeOperator.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Net;
+using System.Numerics;
 
 namespace NetTools.Internals
 {
     internal interface IRangeOperator : ICollection<IPAddress>
     {
         bool Contains(IPAddressRange range);
+
+        BigInteger AddressCount { get; }
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+v.6.2.0
+- Added AddressCount property to retrieve number of addresses contained by range
+
 v.6.1.0
 - Add support for .NET 9.0
 


### PR DESCRIPTION
Currently, there's no easy way to get total address count.
The easiest way is to cast enumerable from `.AsEnumerable()` to `ICollection<IPAddress>` and use the `Count` property, but it's not straightforward (requires reading of the source code) and doesn't work for large ranges like IPv6 `/64`.

I've added `AddressCount` property which does that calculation in `BigInteger` terms, working for both IPv4 and IPv6 cases. Admit, it's less performant than `Int32` in IPv4 case; maybe we need separate property which throws overflow exceptions if result exceeds `int.MaxValue`.